### PR TITLE
Feat: Fetch Hook과 Fuzzy Matching 알고리즘 합치기

### DIFF
--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -6,6 +6,8 @@ export { useState, useEffect, useLayoutEffect, useCallback, useContext, useMemo,
 
 export { useAppDispatch } from './useAppDispatch'
 export { useAppSelector } from './useAppSelector'
+export { useDebounce } from './useDebounce'
+export { useFilteredQuery } from './useFilteredQuery'
 
 export function useMounted(): boolean {
   const [mounted, setMounted] = useState(false)

--- a/src/hooks/useFilteredQuery.ts
+++ b/src/hooks/useFilteredQuery.ts
@@ -16,6 +16,8 @@ export const useFilteredQuery = () => {
     cacheTime: Infinity,
     enabled: searchText !== '',
     onSuccess: () => {
+      // 과제 요구사항 중 콘솔에 출력하는 부분이 있기 때문에 Eslint 무시 설정
+      // eslint-disable-next-line no-console
       console.log('fetched')
     },
   })

--- a/src/hooks/useFilteredQuery.ts
+++ b/src/hooks/useFilteredQuery.ts
@@ -10,8 +10,8 @@ export const useFilteredQuery = () => {
   const fuzzyRegExpString = fuzzyMatchingRegExp(searchText)
   const { data } = useQuery(['#diseaseData', searchText], () => getDiseaseDataFiltered(searchText), {
     refetchOnWindowFocus: false,
-    suspense: true,
-    useErrorBoundary: true,
+    suspense: true, // TODO: suspense 필요 없다면 삭제 가능
+    useErrorBoundary: true, // TODO: Error boundary 필요 없다면 삭제 가능
     staleTime: 60000,
     cacheTime: Infinity,
     enabled: searchText !== '',

--- a/src/services/getDiseaseDataFiltered.ts
+++ b/src/services/getDiseaseDataFiltered.ts
@@ -1,5 +1,6 @@
-import { IDiseaseDataItem } from 'types/types'
 import axios from 'axios'
+
+import { IDiseaseDataItem } from 'types/types'
 import { fuzzyMatchingRegExp } from 'utils'
 
 export const getDiseaseDataFiltered = (searchText: string) =>

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,5 +1,3 @@
-import { getDiseaseData } from './getDiseaseData'
+export { getDiseaseData } from './getDiseaseData'
 
-import { getDiseaseDataFiltered } from './getDiseaseDataFiltered'
-
-export { getDiseaseData, getDiseaseDataFiltered }
+export { getDiseaseDataFiltered } from './getDiseaseDataFiltered'

--- a/src/utils/fuzzyMathcingRegExp.ts
+++ b/src/utils/fuzzyMathcingRegExp.ts
@@ -1,8 +1,9 @@
-import { koreanCharAt } from "./koreanCharAt";
-export const fuzzyMatchingRegExp = (value : string) => {
+import { koreanCharAt } from './koreanCharAt'
+
+export const fuzzyMatchingRegExp = (value: string) => {
   const fuzzyString = value
-    .split("")
+    .split('')
     .map((char) => `(${koreanCharAt(char)})`)
-    .join(".*?");
-  return fuzzyString;
-};
+    .join('.*?')
+  return fuzzyString
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,0 +1,7 @@
+import { fuzzyMatchingRegExp } from './fuzzyMathcingRegExp'
+
+import { koreanCharAt } from './koreanCharAt'
+
+import { makeMarkedString } from './makeMarkedString'
+
+export { fuzzyMatchingRegExp, koreanCharAt, makeMarkedString }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,7 +1,5 @@
 import { fuzzyMatchingRegExp } from './fuzzyMathcingRegExp'
 
-import { koreanCharAt } from './koreanCharAt'
-
 import { makeMarkedString } from './makeMarkedString'
 
-export { fuzzyMatchingRegExp, koreanCharAt, makeMarkedString }
+export { fuzzyMatchingRegExp, makeMarkedString }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,5 +1,3 @@
-import { fuzzyMatchingRegExp } from './fuzzyMathcingRegExp'
+export { fuzzyMatchingRegExp } from './fuzzyMathcingRegExp'
 
-import { makeMarkedString } from './makeMarkedString'
-
-export { fuzzyMatchingRegExp, makeMarkedString }
+export { makeMarkedString } from './makeMarkedString'

--- a/src/utils/koreanCharAt.ts
+++ b/src/utils/koreanCharAt.ts
@@ -1,18 +1,12 @@
-export const koreanCharAt = (target : string) => {
-  const offSet = "가".charCodeAt(0);
+export const koreanCharAt = (target: string) => {
+  const offSet = '가'.charCodeAt(0)
   if (target.charCodeAt(0) >= offSet) {
-    if ((target.charCodeAt(0) - offSet) % 28 > 0) return target;
-    const start =
-      target.charCodeAt(0) -
-      offSet -
-      ((target.charCodeAt(0) - offSet) % 28) +
-      offSet;
-    const end = start + 27;
-    const regExpString = `[${target}\\u${start.toString(16)}-\\u${end.toString(
-      16
-    )}]`;
-    return regExpString;
+    if ((target.charCodeAt(0) - offSet) % 28 > 0) return target
+    const start = target.charCodeAt(0) - offSet - ((target.charCodeAt(0) - offSet) % 28) + offSet
+    const end = start + 27
+    const regExpString = `[${target}\\u${start.toString(16)}-\\u${end.toString(16)}]`
+    return regExpString
   }
 
-  return target;
-};
+  return target
+}

--- a/src/utils/makeMarkedString.ts
+++ b/src/utils/makeMarkedString.ts
@@ -1,41 +1,38 @@
-interface IResult {
-  correctness: number,
-  distance: number,
-  highlighted: number[],
-}
+import { IDiseaseDataItem } from 'types/types'
 
-interface Item {
-  sickNm: string,
-  sickCd: string
+interface IResult {
+  correctness: number
+  distance: number
+  highlighted: number[]
 }
 
 const dfs = (
-  start : number,
-  valueArr : string[],
-  fuzzyArr : string[],
-  inputArr : string[],
-  correctness : number,
-  distance : number,
-  highlighted : number[]
+  start: number,
+  valueArr: string[],
+  fuzzyArr: string[],
+  inputArr: string[],
+  correctness: number,
+  distance: number,
+  highlighted: number[]
 ) => {
   if (fuzzyArr.length === 0) {
-    const newHighlighted = [...highlighted];
+    const newHighlighted = [...highlighted]
     return [
       {
         correctness,
         distance,
         highlighted: newHighlighted,
       },
-    ];
+    ]
   }
-  let result : IResult[] = [];
-  let newHighlighted = [...highlighted];
-  const fuzzyRegExp = new RegExp(fuzzyArr[0]);
+  let result: IResult[] = []
+  const newHighlighted = [...highlighted]
+  const fuzzyRegExp = new RegExp(fuzzyArr[0])
   valueArr.forEach((alpha, idx) => {
     if (fuzzyRegExp.test(alpha)) {
-      const isCorrect = alpha === inputArr[0] ? 1 : 0;
-      const maxDistance = start === 0 ? 1 : Math.max(distance, idx + 1);
-      newHighlighted.push(start + idx);
+      const isCorrect = alpha === inputArr[0] ? 1 : 0
+      const maxDistance = start === 0 ? 1 : Math.max(distance, idx + 1)
+      newHighlighted.push(start + idx)
       const newArr = dfs(
         start + idx + 1,
         valueArr.slice(idx + 1),
@@ -44,36 +41,21 @@ const dfs = (
         correctness + isCorrect,
         maxDistance,
         newHighlighted
-      );
-      newHighlighted.pop();
-      result = [...result, ...newArr];
+      )
+      newHighlighted.pop()
+      result = [...result, ...newArr]
     }
-  });
-  return result;
-};
+  })
+  return result
+}
 
-const makeMarkedString = (item : Item, fuzzyString : string, searchText: string) => {
-  const canBeMarkedArr = dfs(
-    0,
-    item.sickNm.split(""),
-    fuzzyString.split(".*?"),
-    searchText.split(""),
-    0,
-    1,
-    []
-  );
+export const makeMarkedString = (item: IDiseaseDataItem, fuzzyString: string, searchText: string) => {
+  const canBeMarkedArr = dfs(0, item.sickNm.split(''), fuzzyString.split('.*?'), searchText.split(''), 0, 1, [])
   const sortedMarkedArr = canBeMarkedArr.sort((a, b) => {
-    if (a.correctness < b.correctness) {
-      return 1;
-    } else if (a.correctness > b.correctness) {
-      return -1;
-    }
-    if (a.distance < b.distance) {
-      return -1;
-    }
-    return 1;
-  });
-  return sortedMarkedArr[0];
-};
-
-export default makeMarkedString;
+    if (a.correctness < b.correctness) return 1
+    if (a.correctness > b.correctness) return -1
+    if (a.distance < b.distance) return -1
+    return 1
+  })
+  return sortedMarkedArr[0]
+}


### PR DESCRIPTION
- 퍼지매칭 알고리즘 함수들에 Eslint, Prettier 적용하였습니다
- `fuzzyMatchingRegExp` 함수를 `useFilteredQuery` 훅이 사용하는 Fetching 함수 내에서 사용하여 정규식 문자열을 받아오도록 하였습니다
- 경로 수정 및 Redux toolkit Provider 컴포넌트 사용 때문에 발생한 충돌 수정
- 이제 `useFilteredQuery` 훅은 정상적으로 필터링된 데이터를 캐싱할 것입니다?
- `makeMarkedString` 함수는 드롭다운 출력 시에 필요한 부분이라 index.ts에서 export 처리만 해 두었습니다